### PR TITLE
Bugfix: Allow ID Strings

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -53,7 +53,7 @@ impl<'a> Dot<'a> {
         write!(w, "{}{}", strict, &graph.graph_type())?;
 
         if let Some(id) = &graph.id {
-            write!(w, " {}", id)?;
+            write!(w, " {}", format_id(&id))?;
         }
 
         writeln!(w, " {{")?;
@@ -187,9 +187,9 @@ impl<'a> Dot<'a> {
             w,
             "{}{} {} {}",
             get_indentation(indentation_level),
-            edge_source,
+            format_id(&edge_source),
             edge_op,
-            edge_target
+            format_id(&edge_target)
         )?;
         write!(w, "{}", fmt_attributes(&edge.attributes))?;
         writeln!(w, ";")
@@ -638,7 +638,7 @@ impl<'a> Node<'a> {
 
 impl<'a> DotString<'a> for Node<'a> {
     fn dot_string(&self) -> Cow<'a, str> {
-        let mut dot_string = format!("{}", &self.id);
+        let mut dot_string = format!("{}", format_id(&self.id));
         dot_string.push_str(fmt_attributes(&self.attributes).as_str());
         dot_string.push_str(";");
         dot_string.into()
@@ -964,4 +964,16 @@ impl<'a> EdgeAttributeStatementBuilder<'a> {
 
 fn get_indentation(indentation_level: usize) -> String {
     INDENT.repeat(indentation_level)
+}
+
+// According to https://graphviz.org/doc/info/lang.html we should wrap strings with spaces aka
+// double-quoted strings as well as escape double quotes within those strings.
+// This probably needs to be more robust but I think for now it fixes a but around double-quoted
+// strings
+fn format_id(val: &String) -> String {
+    if val.contains(char::is_whitespace) || val.contains("\"") {
+        return format!("\"{}\"", val.escape_default())
+    }
+
+    val.to_string()
 }

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -53,7 +53,7 @@ impl<'a> Dot<'a> {
         write!(w, "{}{}", strict, &graph.graph_type())?;
 
         if let Some(id) = &graph.id {
-            write!(w, " {}", format_id(&id))?;
+            write!(w, " {}", &id.dot_string())?;
         }
 
         writeln!(w, " {{")?;
@@ -187,9 +187,9 @@ impl<'a> Dot<'a> {
             w,
             "{}{} {} {}",
             get_indentation(indentation_level),
-            format_id(&edge_source),
+            AttributeText::from(edge_source).dot_string(),
             edge_op,
-            format_id(&edge_target)
+            AttributeText::from(edge_target).dot_string(),
         )?;
         write!(w, "{}", fmt_attributes(&edge.attributes))?;
         writeln!(w, ";")
@@ -224,7 +224,7 @@ pub enum RenderOption {
 
 #[derive(Clone, Debug)]
 pub struct Graph<'a> {
-    pub id: Option<String>,
+    pub id: Option<AttributeText<'a>>,
 
     pub is_directed: bool,
 
@@ -248,7 +248,7 @@ pub struct Graph<'a> {
 
 impl<'a> Graph<'a> {
     pub fn new(
-        id: Option<String>,
+        id: Option<AttributeText<'a>>,
         is_directed: bool,
         strict: bool,
         comment: Option<String>,
@@ -291,7 +291,7 @@ impl<'a> Graph<'a> {
 }
 
 pub struct GraphBuilder<'a> {
-    id: Option<String>,
+    id: Option<AttributeText<'a>>,
 
     is_directed: bool,
 
@@ -314,13 +314,12 @@ pub struct GraphBuilder<'a> {
     errors: Vec<ValidationError>,
 }
 
-// TODO: id should be an escString
 impl<'a> GraphBuilder<'a> {
     pub fn new_directed() -> Self {
         Self::new(None, true)
     }
 
-    pub fn new_named_directed<S: Into<String>>(id: S) -> Self {
+    pub fn new_named_directed<S: Into<AttributeText<'a>>>(id: S) -> Self {
         Self::new(Some(id.into()), true)
     }
 
@@ -328,11 +327,11 @@ impl<'a> GraphBuilder<'a> {
         Self::new(None, false)
     }
 
-    pub fn new_named_undirected<S: Into<String>>(id: S) -> Self {
+    pub fn new_named_undirected<S: Into<AttributeText<'a>>>(id: S) -> Self {
         Self::new(Some(id.into()), false)
     }
 
-    fn new(id: Option<String>, is_directed: bool) -> Self {
+    fn new(id: Option<AttributeText<'a>>, is_directed: bool) -> Self {
         Self {
             id,
             is_directed,
@@ -433,7 +432,7 @@ impl<'a> GraphBuilder<'a> {
 
     pub fn build_ignore_validation(&self) -> Graph<'a> {
         Graph {
-            id: self.id.to_owned(),
+            id: self.id.to_owned().into(),
             is_directed: self.is_directed,
             strict: self.strict,
             comment: self.comment.clone(), // TODO: is clone the only option here?
@@ -622,12 +621,12 @@ impl<'a> SubGraphBuilder<'a> {
 
 #[derive(Clone, Debug)]
 pub struct Node<'a> {
-    pub id: String,
+    pub id: AttributeText<'a>,
     pub attributes: IndexMap<String, AttributeText<'a>>,
 }
 
 impl<'a> Node<'a> {
-    pub fn new<S: Into<String>>(id: S) -> Node<'a> {
+    pub fn new<S: Into<AttributeText<'a>>>(id: S) -> Node<'a> {
         // TODO: constrain id
         Node {
             id: id.into(),
@@ -638,7 +637,7 @@ impl<'a> Node<'a> {
 
 impl<'a> DotString<'a> for Node<'a> {
     fn dot_string(&self) -> Cow<'a, str> {
-        let mut dot_string = format!("{}", format_id(&self.id));
+        let mut dot_string = format!("{}", &self.id.dot_string());
         dot_string.push_str(fmt_attributes(&self.attributes).as_str());
         dot_string.push_str(";");
         dot_string.into()
@@ -701,7 +700,7 @@ impl<'a> NodeBuilder<'a> {
     pub fn build_ignore_validation(&self) -> Node<'a> {
         Node {
             // TODO: are these to_owned and clones necessary?
-            id: self.id.to_owned(),
+            id: self.id.to_owned().into(),
             attributes: self.attributes.clone(),
         }
     }
@@ -964,16 +963,4 @@ impl<'a> EdgeAttributeStatementBuilder<'a> {
 
 fn get_indentation(indentation_level: usize) -> String {
     INDENT.repeat(indentation_level)
-}
-
-// According to https://graphviz.org/doc/info/lang.html we should wrap strings with spaces aka
-// double-quoted strings as well as escape double quotes within those strings.
-// This probably needs to be more robust but I think for now it fixes a but around double-quoted
-// strings
-fn format_id(val: &String) -> String {
-    if val.contains(char::is_whitespace) || val.contains("\"") {
-        return format!("\"{}\"", val.escape_default())
-    }
-
-    val.to_string()
 }

--- a/tests/dot.rs
+++ b/tests/dot.rs
@@ -63,9 +63,61 @@ digraph {
 }
 
 #[test]
-fn quotted_id() {
-    let quotted_id = r#"Earvin "Magic" Johnson"#;
-    let g = GraphBuilder::new_named_directed(quotted_id)
+fn nonreadable_ascii_id() {
+    let id = "\u{0}\u{1}\u{2}\u{3}\u{4}\u{5}\u{6}\u{7}\u{8}\u{9}\u{a}\u{b}\u{c}\u{d}\u{e}\u{f}\
+        \u{10}\u{11}\u{12}\u{13}\u{14}\u{15}\u{16}\u{17}\u{18}\u{19}\u{1a}\u{1b}\u{1c}\u{1d}\u{1e}\
+        \u{1f}";
+
+    let g = GraphBuilder::new_named_directed(id)
+        .build()
+        .unwrap();
+    let r = test_input(g);
+    assert_eq!(
+        r.unwrap(),
+        "digraph \"\u{0}\u{1}\u{2}\u{3}\u{4}\u{5}\u{6}\u{7}\u{8}\u{9}\u{a}\u{b}\u{c}\u{d}\u{e}\
+            \u{f}\u{10}\u{11}\u{12}\u{13}\u{14}\u{15}\u{16}\u{17}\u{18}\u{19}\u{1a}\u{1b}\u{1c}\
+            \u{1d}\u{1e}\u{1f}\" {
+}
+"
+    );
+}
+
+#[test]
+fn readable_ascii_no_alphanum_id() {
+    let id = r##" !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##;
+
+    let g = GraphBuilder::new_named_directed(id)
+        .build()
+        .unwrap();
+    let r = test_input(g);
+    assert_eq!(
+        r.unwrap(),
+        r##"digraph " !\"#$%&'()*+,-./:;<=>?@[\]^_`{|}~" {
+}
+"##
+    );
+}
+
+#[test]
+fn non_ascii_alphanum_id() {
+    let id = "Identität";
+
+    let g = GraphBuilder::new_named_directed(id)
+        .build()
+        .unwrap();
+    let r = test_input(g);
+    assert_eq!(
+        r.unwrap(),
+        r##"digraph Identität {
+}
+"##
+    );
+}
+
+#[test]
+fn quoted_id() {
+    let quoted_id = r#"Earvin "Magic" Johnson"#;
+    let g = GraphBuilder::new_named_directed(quoted_id)
         .build()
         .unwrap();
     let r = test_input(g);
@@ -238,8 +290,11 @@ fn format_edges() {
 
     let r = test_input(g);
 
+    let s = r.unwrap();
+    println!("{}", s);
+
     assert_eq!(
-        r.unwrap(),
+        s,
         r#"digraph format_edges {
     "Earvin \"Magic\" Johnson";
     "A Graph";
@@ -316,7 +371,7 @@ fn edge_statement_port_position() {
         r#"digraph edge_statement_port_position {
     N0 [shape=record, label="a|<port0>b"];
     N1 [shape=record, label="e|<port1>f"];
-    N0:port0:sw -> N1:port1:ne;
+    "N0:port0:sw" -> "N1:port1:ne";
 }
 "#
     );

--- a/tests/dot.rs
+++ b/tests/dot.rs
@@ -63,6 +63,36 @@ digraph {
 }
 
 #[test]
+fn quotted_id() {
+    let quotted_id = r#"Earvin "Magic" Johnson"#;
+    let g = GraphBuilder::new_named_directed(quotted_id)
+        .build()
+        .unwrap();
+    let r = test_input(g);
+    assert_eq!(
+        r.unwrap(),
+        r#"digraph "Earvin \"Magic\" Johnson" {
+}
+"#
+    );
+}
+
+#[test]
+fn id_with_space() {
+    let id = "A Graph";
+    let g = GraphBuilder::new_named_directed(id)
+        .build()
+        .unwrap();
+    let r = test_input(g);
+    assert_eq!(
+        r.unwrap(),
+        r#"digraph "A Graph" {
+}
+"#
+    );
+}
+
+#[test]
 fn empty_digraph() {
     let g = GraphBuilder::new_named_directed("empty_graph")
         .build()
@@ -192,6 +222,28 @@ fn single_edge() {
     N0;
     N1;
     N0 -> N1;
+}
+"#
+    );
+}
+
+#[test]
+fn format_edges() {
+    let g = GraphBuilder::new_named_directed("format_edges")
+        .add_node(Node::new(r#"Earvin "Magic" Johnson"#))
+        .add_node(Node::new("A Graph"))
+        .add_edge(Edge::new(r#"Earvin "Magic" Johnson"#, "A Graph"))
+        .build()
+        .unwrap();
+
+    let r = test_input(g);
+
+    assert_eq!(
+        r.unwrap(),
+        r#"digraph format_edges {
+    "Earvin \"Magic\" Johnson";
+    "A Graph";
+    "Earvin \"Magic\" Johnson" -> "A Graph";
 }
 "#
     );


### PR DESCRIPTION
A user, Martin, reached out about a bug with IDs specifically with
quoting. Dotavious initially just used the string provided by caller
however this is problematic for a few different scenarios amongst others

1. Strings with spaces
2. Double-quoted strings

Details about IDs can be found at https://graphviz.org/doc/info/lang.html

This commit conditional formats IDs based on the following

1. Wrap string in quotes if there is a blank
2. Escape quotes found in string

My rationale for conditionally formatting is mostly around keeping
previous behavior intact. Quote from the link above

An ID is just a string; the lack of quote characters in the first two forms is just for simplicity.
There is no semantic difference between abc_2 and "abc_2", or between 2.34 and "2.34"

Given these IDs are semantically the same I wanted to keep the same
formatting which is unquoted.

NOTE: This does not address HTML strings as IDs which needs to be
addressed at a later date.